### PR TITLE
Updated admissionregistration API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ is applied, and the user ID defaults to `1234`.
 ## Prerequisites
 
 A cluster on which this example can be tested must be running Kubernetes 1.9.0 or above,
-with the `admissionregistration.k8s.io/v1beta1` API enabled. You can verify that by observing that the
+with the `admissionregistration.k8s.io/v1` API enabled. You can verify that by observing that the
 following command produces a non-empty output:
 ```
-kubectl api-versions | grep admissionregistration.k8s.io/v1beta1
+kubectl api-versions | grep admissionregistration.k8s.io/v1
 ```
 In addition, the `MutatingAdmissionWebhook` admission controller should be added and listed in the admission-control
 flag of `kube-apiserver`.


### PR DESCRIPTION
Updated API Version of the Kubernetes resource admissionregistration.k8s.io/ from v1beta1 to v1